### PR TITLE
Fix: Terminal execution of Ctrl + C does not terminate the process

### DIFF
--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -12,7 +12,7 @@ const logUpdate = new LogUpdate()
 let lastRender = Date.now()
 
 export default class FancyReporter implements Reporter {
-  constructor() {
+  constructor () {
     if (process) {
       process.on('SIGINT', () => {
         const exitCode = process.exit(1)

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -14,13 +14,16 @@ let lastRender = Date.now()
 export default class FancyReporter implements Reporter {
   constructor () {
     if (process) {
+      const exitCode = 1
+      process.exitCode = exitCode
       process.on('SIGINT', () => {
-        const exitCode = process.exit(1)
-        process.kill(exitCode, 'SIGINT')
+        process.exit(exitCode)
+        /* eslint no-unreachable: 0 */
+        process.exit(exitCode)
       })
     }
   }
-  
+
   allDone () {
     logUpdate.done()
   }

--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -12,6 +12,15 @@ const logUpdate = new LogUpdate()
 let lastRender = Date.now()
 
 export default class FancyReporter implements Reporter {
+  constructor() {
+    if (process) {
+      process.on('SIGINT', () => {
+        const exitCode = process.exit(1)
+        process.kill(exitCode, 'SIGINT')
+      })
+    }
+  }
+  
   allDone () {
     logUpdate.done()
   }


### PR DESCRIPTION
When the fancy reporter is running, it cannot exit the terminal correctly.