### PR TITLE
feat: replace text-table with markdown-table

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "chalk": "^4.1.0",
     "consola": "^2.15.0",
     "figures": "^3.2.0",
+    "markdown-table": "^2.0.0",
     "pretty-time": "^1.1.0",
     "std-env": "^2.2.1",
-    "text-table": "^0.2.0",
     "wrap-ansi": "^7.0.0"
   },
   "devDependencies": {

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 import Consola from 'consola'
-
-import textTable from 'text-table'
+import markdownTable from 'markdown-table'
 
 import { BLOCK_CHAR, BLOCK_CHAR2, BAR_LENGTH } from './consts'
 
@@ -28,9 +27,7 @@ export const renderBar = (progress, color) => {
 }
 
 export function createTable (data) {
-  return textTable(data, {
-    align: data[0].map(() => 'l')
-  }).replace(/\n/g, '\n\n')
+  return markdownTable(data)
 }
 
 export function ellipsis (str, n) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4283,6 +4283,13 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-table@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-2.0.0.tgz#194a90ced26d31fe753d8b9434430214c011865b"
+  integrity sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==
+  dependencies:
+    repeat-string "^1.0.0"
+
 memory-fs@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.5.0.tgz#324c01288b88652966d161db77838720845a8e3c"
@@ -5181,7 +5188,7 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.6.1:
+repeat-string@^1.0.0, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=


### PR DESCRIPTION
Markdown's more compact, has rules, and can be used in GitHub/GitLab comments.

## Size

- text-table [![min size](https://badgen.net/bundlephobia/min/text-table)](https://bundlephobia.com/result?p=text-table)
- markdown-table [![min size](https://badgen.net/bundlephobia/min/markdown-table)](https://bundlephobia.com/result?p=markdown-table)

## Before

```
Profile results for Server

> Stats by Ext

Ext    Requests  Time   Time/Request  Description

js     5582      6s     989μs         JavaScript files

css    2063      2s     960μs         css files

svg    323       499ms  2ms           svg files

png    622       451ms  725μs         png files

gif    14        6ms    413μs         gif files

jpg    35        5ms    139μs         jpg files

md     1         1ms    1ms           md files

Total  8640      8s

...
```

## After

```
Profile results for Server

> Stats by Ext

| Ext   | Requests | Time  | Time/Request | Description      |
| ----- | -------- | ----- | ------------ | ---------------- |
| js    | 5393     | 5s    | 990μs        | JavaScript files |
| css   | 2313     | 2s    | 1ms          | css files        |
| svg   | 316      | 499ms | 2ms          | svg files        |
| md    | 1        | 673μs | 673μs        | md files         |
| png   | 581      | 493ms | 848μs        | png files        |
| jpg   | 36       | 17ms  | 477μs        | jpg files        |
| gif   | 9        | 8ms   | 834μs        | gif files        |
| Total | 8649     | 9s    |              |                  |

...
```

renders to comment:

> Stats by Ext

| Ext   | Requests | Time  | Time/Request | Description      |
| ----- | -------- | ----- | ------------ | ---------------- |
| js    | 5393     | 5s    | 990μs        | JavaScript files |
| css   | 2313     | 2s    | 1ms          | css files        |
| svg   | 316      | 499ms | 2ms          | svg files        |
| md    | 1        | 673μs | 673μs        | md files         |
| png   | 581      | 493ms | 848μs        | png files        |
| jpg   | 36       | 17ms  | 477μs        | jpg files        |
| gif   | 9        | 8ms   | 834μs        | gif files        |
| Total | 8649     | 9s    |              |                  |




