### PR TITLE
fix: automatically add `profile` reporter when `profile` option enabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export default class WebpackBarPlugin extends Webpack.ProgressPlugin {
     const _reporters: ReporterOpts[] = Array
       .from(this.options.reporters || [])
       .concat(this.options.reporter)
+      .concat(this.options.profile && 'profile')
       .filter(Boolean)
       .map((reporter) => {
         if (Array.isArray(reporter)) {


### PR DESCRIPTION
https://github.com/unjs/webpackbar/issues/29#issuecomment-968120938

## Temporary workaround

With bars reporter:

```ts
new Webpackbar({
  reporters: ['fancy', 'profile'],
  profile: true,
}),
```

Without bars reporter:

```ts
new Webpackbar({
  reporters: ['profile'],
  profile: true,
}),
```
